### PR TITLE
updated the case of the "Authorization" header

### DIFF
--- a/index.php
+++ b/index.php
@@ -54,7 +54,7 @@ if ($function == "pushPackages") { //Build and output push package to Safari
 else if ($function == "devices") { // safari is adding or deleting the device
 	$id = "";
 	foreach(apache_request_headers() as $header=>$value) { // this is the authorization key we packaged in the website.json pushPackage
-		if($header == "AUTHORIZATION") {
+		if($header == "Authorization") {
 			$value = explode("_", $value);
 			$id = $value[1];
 			break;


### PR DESCRIPTION
The header sent in /device/ calls is "Authorization" rather than "AUTHORIZATION". It was causing a blank $id to be inserted into the push database table.
